### PR TITLE
Modify docker run command.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Start docker container
 
 ```
-docker run -it --env DISPLAY=$DISPLAY --env USER=$USER --volume /tmp/.X11-unix:/tmp/.X11-unix:ro --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --privileged --runtime nvidia --gpus all --volume ${PWD}/Dataset:/workspace/Dataset --workdir /workspace --name superslam superslam:latest /bin/bash
+docker run -it --env DISPLAY=$DISPLAY --env USER=$USER --volume /tmp/.X11-unix:/tmp/.X11-unix --volume "$HOME/.Xauthority:/root/.Xauthority" --net host --privileged --runtime nvidia --gpus all --volume ${PWD}:/workspace/superslam --workdir /workspace --name superslam superslam:latest /bin/bash
 ```
 
 Build superslam

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Start docker container
 
 ```
-docker run -it --env DISPLAY=$DISPLAY --volume /tmp/.X11-unix:/tmp/.X11-unix --privileged --runtime nvidia --gpus all --volume ${PWD}:/workspace/superslam --workdir /workspace --name superslam superslam:latest /bin/bash
+docker run -it --env DISPLAY=$DISPLAY --env USER=$USER --volume /tmp/.X11-unix:/tmp/.X11-unix:ro --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --privileged --runtime nvidia --gpus all --volume ${PWD}/Dataset:/workspace/Dataset --workdir /workspace --name superslam superslam:latest /bin/bash
 ```
 
 Build superslam

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Start docker container
 
 ```
-docker run -it --env DISPLAY=$DISPLAY --env USER=$USER --volume /tmp/.X11-unix:/tmp/.X11-unix --volume "$HOME/.Xauthority:/root/.Xauthority" --net host --privileged --runtime nvidia --gpus all --volume ${PWD}:/workspace/superslam --workdir /workspace --name superslam superslam:latest /bin/bash
+docker run -it --env DISPLAY=$DISPLAY --env USER=$USER --volume /tmp/.X11-unix:/tmp/.X11-unix --volume "$HOME/.Xauthority:/root/.Xauthority" --net host --privileged --runtime nvidia --gpus all --volume ${PWD}/Dataset:/workspace/Dataset --workdir /workspace --name superslam superslam:latest /bin/bash
 ```
 
 Build superslam


### PR DESCRIPTION
# Background
EC2 환경 container 안의 GUI 확인을 위한 X11 설정이 필요하다. 또한 Docker내에 사용할 Dataset이 mount 되어 있지 않아 테스트가 어려운 문제가 있다.

# Action
- .Xauthority 및 X11 통신을위한 network 추가
- ubuntu에 설치한 KITTIDataset을 docker container에 volume mount

# Results
<img width="1063" alt="스크린샷 2023-08-12 오후 8 08 59" src="https://github.com/prgrms-ad-devcourse/ad-5-final-project-team2/assets/42798237/17488d6e-8535-4916-85e2-816859ae5918">
docker container 환경에서 X11-apps 테스트 정상적으로 GUI를 확인 가능하다.